### PR TITLE
Add basic QUnit test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Juanificate
+
+This repository contains the juanificate jQuery plugin and assets. A small QUnit test suite is provided under the `tests/` directory.
+
+## Running the tests
+
+Because the plugin relies on the browser environment, the tests must be run in a browser. You can serve the repository with any local web server. One simple approach is to use Python:
+
+```bash
+python3 -m http.server
+```
+
+Then open `http://localhost:8000/tests/` in your browser to execute the QUnit test suite.

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Juanificate Tests</title>
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.4.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture">
+    <div id="indepth_content"></div>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-2.1.0/jquery.min.js"></script>
+  <script src="../js/jquery.juanificate.js"></script>
+  <script src="https://code.jquery.com/qunit/qunit-2.19.4.js"></script>
+  <script src="tests.js"></script>
+</body>
+</html>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,14 @@
+QUnit.module('juanificate plugin');
+
+QUnit.test('initializes with default options', function(assert) {
+  var instance = $('#indepth_content').data('juanificate');
+  assert.ok(instance, 'instance is stored in element data');
+  assert.strictEqual(instance.genero, 'hombre', 'default genero');
+  assert.strictEqual(instance.boca, 1, 'default boca');
+  assert.strictEqual(instance.escenario, 1, 'default escenario');
+  assert.strictEqual(instance.ojos, 1, 'default ojos');
+  assert.strictEqual(instance.outfit, 1, 'default outfit');
+  assert.strictEqual(instance.pantalones, 1, 'default pantalones');
+  assert.strictEqual(instance.peinado, 1, 'default peinado');
+  assert.strictEqual(instance.zapatos, 1, 'default zapatos');
+});


### PR DESCRIPTION
## Summary
- add QUnit test page and test verifying default options
- document how to run the browser-based test suite

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f627baa1c833084eaca1db65976bc